### PR TITLE
Make CamelCase class public

### DIFF
--- a/src/Microsoft.JSInterop/Json/CamelCase.cs
+++ b/src/Microsoft.JSInterop/Json/CamelCase.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.JSInterop
 {
-    internal static class CamelCase
+    public static class CamelCase
     {
         public static string MemberNameToCamelCase(string value)
         {


### PR DESCRIPTION
In Blazor-State I am manipulating the json also and would like to reuse this method without duplication.