### PR TITLE
Deserialize classes with non-public constructors, and values for public properties with non-public setters

### DIFF
--- a/src/Microsoft.JSInterop/Json/SimpleJson/SimpleJson.cs
+++ b/src/Microsoft.JSInterop/Json/SimpleJson/SimpleJson.cs
@@ -1332,7 +1332,7 @@ namespace SimpleJson
                 if (propertyInfo.CanWrite)
                 {
                     MethodInfo setMethod = ReflectionUtils.GetSetterMethodInfo(propertyInfo);
-                    if (setMethod.IsStatic || !setMethod.IsPublic)
+                    if (setMethod.IsStatic)
                         continue;
                     if (result.ContainsKey(propertyInfo.Name))
                     {
@@ -1799,7 +1799,7 @@ namespace SimpleJson
 #if SIMPLE_JSON_TYPEINFO
                 return type.GetTypeInfo().DeclaredConstructors;
 #else
-                return type.GetConstructors();
+                return type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 #endif
             }
 

--- a/test/Microsoft.JSInterop.Test/JsonUtilTest.cs
+++ b/test/Microsoft.JSInterop.Test/JsonUtilTest.cs
@@ -145,6 +145,43 @@ namespace Microsoft.JSInterop.Test
         }
 
         [Fact]
+        public void CanCreateInstanceOfClassWithPrivateConstructor()
+        {
+            string expectedName = "NameValue";
+            // Arrange
+            string json = $"{{\"Name\":\"{expectedName}\"}}";
+
+            // Act
+            var instance = Json.Deserialize<PrivateConstructor>(json);
+
+            // Assert
+            Assert.Equal(expectedName, instance.Name);
+        }
+
+        [Fact]
+        public void CanSetValueOfPublicPropertiesWithNonPublicSetters()
+        {
+            // Arrange
+            string expectedPrivateValue = "PrivateValue";
+            string expectedProtectedValue = "ProtectedValue";
+            string expectedInternalValue = "InternalValue";
+
+            string json = "{" +
+                $"\"PrivateSetter\":\"{expectedPrivateValue}\"," +
+                $"\"ProtectedSetter\":\"{expectedProtectedValue}\"," +
+                $"\"InternalSetter\":\"{expectedInternalValue}\"," +
+                "}";
+
+            // Act
+            var instance = Json.Deserialize<NonPublicSetterOnPublicProperty>(json);
+
+            // Assert
+            Assert.Equal(expectedPrivateValue, instance.PrivateSetter);
+            Assert.Equal(expectedProtectedValue, instance.ProtectedSetter);
+            Assert.Equal(expectedInternalValue, instance.InternalSetter);
+        }
+
+        [Fact]
         public void RejectsTypesWithAmbiguouslyNamedProperties()
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
@@ -282,5 +319,25 @@ namespace Microsoft.JSInterop.Test
             public string Member1 { get; set; }
         }
 #pragma warning restore 0649
+        class PrivateConstructor
+        {
+            public string Name { get; set; }
+
+            private PrivateConstructor()
+            {
+            }
+
+            public PrivateConstructor(string name)
+            {
+                Name = name;
+            }
+        }
+
+        class NonPublicSetterOnPublicProperty
+        {
+            public string PrivateSetter { get; private set; }
+            public string ProtectedSetter { get; protected set; }
+            public string InternalSetter { get; internal set; }
+        }
     }
 }


### PR DESCRIPTION
1. Enable instances of classes with non-public constructors to be created.
2. Enable values of public properties with non-public setters to be deserialized.

This is in line with the default settings of Entity Framework Core, and useful for serializing/deserializing instances of immutable state.