### PR TITLE
Added null check for JSRuntime inside DotNetDispatcher

### DIFF
--- a/src/Microsoft.JSInterop/DotNetDispatcher.cs
+++ b/src/Microsoft.JSInterop/DotNetDispatcher.cs
@@ -35,7 +35,7 @@ namespace Microsoft.JSInterop
             // because there would be nobody to police that. This method *is* the police.
 
             // DotNetDispatcher only works with JSRuntimeBase instances.
-            var jsRuntime = (JSRuntimeBase)JSRuntime.Current;
+            var jsRuntime = GetJSRuntimeBase();
 
             var targetInstance = (object)null;
             if (dotNetObjectId != default)
@@ -66,7 +66,7 @@ namespace Microsoft.JSInterop
             // DotNetDispatcher only works with JSRuntimeBase instances.
             // If the developer wants to use a totally custom IJSRuntime, then their JS-side
             // code has to implement its own way of returning async results.
-            var jsRuntimeBaseInstance = (JSRuntimeBase)JSRuntime.Current;
+            var jsRuntimeBaseInstance = GetJSRuntimeBase();
 
             var targetInstance = dotNetObjectId == default
                 ? null
@@ -154,7 +154,7 @@ namespace Microsoft.JSInterop
             }
 
             // Second, convert each supplied value to the type expected by the method
-            var runtime = (JSRuntimeBase)JSRuntime.Current;
+            var runtime = GetJSRuntimeBase();
             var serializerStrategy = runtime.ArgSerializerStrategy;
             for (var i = 0; i < suppliedArgsLength; i++)
             {
@@ -190,7 +190,7 @@ namespace Microsoft.JSInterop
         /// <param name="result">If <paramref name="succeeded"/> is <c>true</c>, specifies the invocation result. If <paramref name="succeeded"/> is <c>false</c>, gives the <see cref="Exception"/> corresponding to the invocation failure.</param>
         [JSInvokable(nameof(DotNetDispatcher) + "." + nameof(EndInvoke))]
         public static void EndInvoke(long asyncHandle, bool succeeded, JSAsyncCallResult result)
-            => ((JSRuntimeBase)JSRuntime.Current).EndInvokeJS(asyncHandle, succeeded, result.ResultOrException);
+            => GetJSRuntimeBase().EndInvokeJS(asyncHandle, succeeded, result.ResultOrException);
 
         /// <summary>
         /// Releases the reference to the specified .NET object. This allows the .NET runtime
@@ -206,7 +206,7 @@ namespace Microsoft.JSInterop
         public static void ReleaseDotNetObject(long dotNetObjectId)
         {
             // DotNetDispatcher only works with JSRuntimeBase instances.
-            var jsRuntime = (JSRuntimeBase)JSRuntime.Current;
+            var jsRuntime = GetJSRuntimeBase();
             jsRuntime.ArgSerializerStrategy.ReleaseDotNetObject(dotNetObjectId);
         }
 
@@ -294,6 +294,18 @@ namespace Microsoft.JSInterop
             }
 
             return ex;
+        }
+
+        private static JSRuntimeBase GetJSRuntimeBase()
+        {
+            JSRuntimeBase runtime = (JSRuntimeBase)JSRuntime.Current;
+
+            if (runtime == null)
+            {
+                throw new InvalidOperationException("JavaScript runtime (" + nameof(JSRuntime) + "." + nameof(JSRuntime.Current) + ") is not set.");
+            }
+
+            return runtime;
         }
     }
 }

--- a/test/Microsoft.JSInterop.Test/DotNetDispatcherTest.cs
+++ b/test/Microsoft.JSInterop.Test/DotNetDispatcherTest.cs
@@ -16,10 +16,22 @@ namespace Microsoft.JSInterop.Test
             = new TestJSRuntime();
 
         [Fact]
+        public void CannotInvokeWithoutJSRuntime()
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+            {
+                DotNetDispatcher.Invoke("SomeAssembly", "SomeMethod", default, "[]");
+            });
+
+            Assert.Equal("JavaScript runtime (" + nameof(JSRuntime) + "." + nameof(JSRuntime.Current) + ") is not set.", ex.Message);
+        }
+
+        [Fact]
         public void CannotInvokeWithEmptyAssemblyName()
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
+                JSRuntime.SetCurrentJSRuntime(jsRuntime);
                 DotNetDispatcher.Invoke(" ", "SomeMethod", default, "[]");
             });
 
@@ -32,6 +44,7 @@ namespace Microsoft.JSInterop.Test
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
+                JSRuntime.SetCurrentJSRuntime(jsRuntime);
                 DotNetDispatcher.Invoke("SomeAssembly", " ", default, "[]");
             });
 
@@ -45,6 +58,7 @@ namespace Microsoft.JSInterop.Test
             var assemblyName = "Some.Fake.Assembly";
             var ex = Assert.Throws<ArgumentException>(() =>
             {
+                JSRuntime.SetCurrentJSRuntime(jsRuntime);
                 DotNetDispatcher.Invoke(assemblyName, "SomeMethod", default, null);
             });
 
@@ -67,6 +81,7 @@ namespace Microsoft.JSInterop.Test
         {
             var ex = Assert.Throws<ArgumentException>(() =>
             {
+                JSRuntime.SetCurrentJSRuntime(jsRuntime);
                 DotNetDispatcher.Invoke(thisAssemblyName, methodIdentifier, default, null);
             });
 
@@ -236,6 +251,7 @@ namespace Microsoft.JSInterop.Test
             // Act/Assert
             var ex = Assert.Throws<ArgumentException>(() =>
             {
+                JSRuntime.SetCurrentJSRuntime(jsRuntime);
                 DotNetDispatcher.Invoke(thisAssemblyName, "InvocableStaticWithParams", default, argsJson);
             });
 


### PR DESCRIPTION
We are writing our own application host which is able to run in web assembly and we are using Blazor in our special way.

The last couple of days I was facing a hidden problem about *JSRuntime*. Even when we registered runtime through method **JsRuntime.SetCurrentJSRuntime** an interop from JS to .NET didn't work. The problem was a combination of where we call the registration method and *AsyncLocal* which is used inside.

My proposal is to do a null check on **JSRuntime.Current** inside *DotNetDispatcher* class and generate more meaningful exception rather a *NullReferenceException*.

**Current state:**
![null-exception](https://user-images.githubusercontent.com/9326601/54140092-ca934b80-441a-11e9-8cf8-9bb98ba96976.png)

**Proposed state:**
![invalid-exception](https://user-images.githubusercontent.com/9326601/54140104-ce26d280-441a-11e9-8f5d-322aaa8c5c7d.png)
